### PR TITLE
use key and not value to avoid clashes

### DIFF
--- a/app/code/local/RobbieAverill/AttributeFix/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
+++ b/app/code/local/RobbieAverill/AttributeFix/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
@@ -78,7 +78,7 @@ class RobbieAverill_AttributeFix_Model_Resource_Product_Type_Configurable_Attrib
                 // Add the attribute options, but in the relevant order rather than by ID
                 foreach (array_intersect_key($optionsByValue, array_flip($toAdd)) as $optionValueKey => $optionValue) {
                     // If option available in associated product
-                    if (!isset($values[$item->getId() . ':' . $optionValue])) {
+                    if (!isset($values[$item->getId() . ':' . $optionValueKey])) {
                         // If option not added, we will add it.
                         $values[$item->getId() . ':' . $optionValueKey] = array(
                             'product_super_attribute_id' => $item->getId(),


### PR DESCRIPTION
this will fail if there is a clash between the index and the value

8627:6  | 8627:20
8627:8  | 8627:19
8627:10 | 8627:18
8627:12 | 8627:17
8627:14 | 8627:16 <!-- option 14 uses index 16
8627:16 | 8627:214 <!-- which then clashes
